### PR TITLE
disable tagpr release note generation to avoid duplication with GoRel…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: write

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,11 +46,24 @@ snapshot:
   name_template: "{{ incpatch .Version }}-next"
 
 changelog:
+  use: github
   sort: asc
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999
   filters:
     exclude:
       - '^docs:'
       - '^test:'
+      - '^ci:'
+      - '^chore:'
+      - '^build:'
 
 release:
   github:

--- a/.tagpr
+++ b/.tagpr
@@ -2,3 +2,4 @@
 vPrefix = true
 releaseBranch = main
 versionFile = VERSION
+releaseNote = false


### PR DESCRIPTION
…easer

Both tagpr and GoReleaser were generating release notes, causing duplication. This change disables tagpr's release note feature while keeping its tag creation functionality. GoReleaser will handle all release note generation going forward.

## Summary
<!-- Summary, purpose, background, ... -->

## Changes
<!-- Changes and images ( screenshots of changes) -->
<!-- If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it. -->

## Others
<!-- Notes to reviewers, consultation and concerns -->
